### PR TITLE
Use time.perf_counter instead of time.time

### DIFF
--- a/jetpack/timepiece.py
+++ b/jetpack/timepiece.py
@@ -11,17 +11,17 @@ __all__ = ['hrtime', 'Stopwatch', 'profile']
 class Stopwatch():
   def __init__(self, name=''):
     self.name = name
-    self.start = time.time()
-    self.absolute_start = time.time()
+    self.start = time.perf_counter()
+    self.absolute_start = time.perf_counter()
 
   def __str__(self):
     return u'\u231a  Stopwatch for: ' + self.name
 
   @property
   def elapsed(self):
-    current = time.time()
+    current = time.perf_counter()
     elapsed = current - self.start
-    self.start = time.time()
+    self.start = time.perf_counter()
     return elapsed
 
   def checkpoint(self, name=''):
@@ -37,7 +37,7 @@ class Stopwatch():
   def __exit__(self, type, value, traceback):
     print(u'{timer} Finished! \u2714\nTotal elapsed time: {total}'.format(
         timer=self.name,
-        total=hrtime(time.time() - self.absolute_start)
+        total=hrtime(time.perf_counter() - self.absolute_start)
     ))
 
 
@@ -101,9 +101,9 @@ def profile(func):
 
   @wraps(func)
   def wrapper(*args, **kwargs):
-      tstart = time.time()
+      tstart = time.perf_counter()
       results = func(*args, **kwargs)
-      tstop = time.time()
+      tstop = time.perf_counter()
       calls.append(tstop - tstart)
       return results
 


### PR DESCRIPTION
See https://docs.python.org/3/library/time.html#time.perf_counter; time.perf_counter should be used for performance measurements.

These changes are entirely untested. 

# Performance changes
## `python3.8 -m timeit -vvvvv 'time.time() - time.time()'`
```
1 loop -> 2.731e-06 secs
2 loops -> 1.617e-06 secs
5 loops -> 2.275e-06 secs
10 loops -> 3.926e-06 secs
20 loops -> 7.546e-06 secs
50 loops -> 1.842e-05 secs
100 loops -> 5.9536e-05 secs
200 loops -> 7.883e-05 secs
500 loops -> 0.000194123 secs
1000 loops -> 0.000410747 secs
2000 loops -> 0.000706704 secs
5000 loops -> 0.001761156 secs
10000 loops -> 0.003544081 secs
20000 loops -> 0.009731159 secs
50000 loops -> 0.01932015 secs
100000 loops -> 0.03682307 secs
200000 loops -> 0.07023627 secs
500000 loops -> 0.1915937 secs
1000000 loops -> 0.3505069 secs

raw times: 340.1403 msec, 347.3075 msec, 336.8322 msec, 336.1656 msec, 338.9545 msec

1000000 loops, best of 5: 336.1656 nsec per loop
```
## `python3.8 -m timeit -vvvvv 'time.perf_counter() - time.perf_counter()'`
```
1 loop -> 2.081e-06 secs
2 loops -> 2.551e-06 secs
5 loops -> 4.011e-06 secs
10 loops -> 7.107e-06 secs
20 loops -> 1.332e-05 secs
50 loops -> 3.2143e-05 secs
100 loops -> 6.3795e-05 secs
200 loops -> 0.00010457 secs
500 loops -> 0.000293773 secs
1000 loops -> 0.000447542 secs
2000 loops -> 0.000861884 secs
5000 loops -> 0.002183934 secs
10000 loops -> 0.003578807 secs
20000 loops -> 0.007985933 secs
50000 loops -> 0.02508519 secs
100000 loops -> 0.05550567 secs
200000 loops -> 0.07348392 secs
500000 loops -> 0.1892336 secs
1000000 loops -> 0.3787163 secs

raw times: 361.4678 msec, 349.8074 msec, 362.9233 msec, 368.9578 msec, 354.8154 msec

1000000 loops, best of 5: 349.8074 nsec per loop
```
