### PR TITLE
Remove extraneous print from yclamp

### DIFF
--- a/jetplot/chart_utils.py
+++ b/jetplot/chart_utils.py
@@ -190,7 +190,6 @@ def yclamp(y0=None, y1=None, dt=None, **kwargs):
     y0 = lims[0] if y0 is None else y0
     y1 = lims[1] if y1 is None else y1
     dt = np.mean(np.diff(ax.get_yticks())) if dt is None else dt
-    print("hello world")
 
     new_ticks = np.arange(dt * np.floor(y0 / dt), dt * (np.ceil(y1 / dt) + 1), dt)
     ax.set_yticks(new_ticks)


### PR DESCRIPTION
## Summary
- remove stray debug statement from `chart_utils.yclamp`

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*