### PR TITLE
Fix clamp helper limits and correlation mode

### DIFF
--- a/jetplot/chart_utils.py
+++ b/jetplot/chart_utils.py
@@ -190,12 +190,10 @@ def yclamp(y0=None, y1=None, dt=None, **kwargs):
     y0 = lims[0] if y0 is None else y0
     y1 = lims[1] if y1 is None else y1
     dt = np.mean(np.diff(ax.get_yticks())) if dt is None else dt
-    print("hello world")
-
     new_ticks = np.arange(dt * np.floor(y0 / dt), dt * (np.ceil(y1 / dt) + 1), dt)
     ax.set_yticks(new_ticks)
     ax.set_yticklabels(new_ticks)
-    ax.set_ylim(new_ticks[0], new_ticks[1])
+    ax.set_ylim(new_ticks[0], new_ticks[-1])
 
     return ax
 
@@ -212,6 +210,6 @@ def xclamp(x0=None, x1=None, dt=None, **kwargs):
     new_ticks = np.arange(dt * np.floor(x0 / dt), dt * (np.ceil(x1 / dt) + 1), dt)
     ax.set_xticks(new_ticks)
     ax.set_xticklabels(new_ticks)
-    ax.set_xlim(new_ticks[0], new_ticks[1])
+    ax.set_xlim(new_ticks[0], new_ticks[-1])
 
     return ax

--- a/jetplot/images.py
+++ b/jetplot/images.py
@@ -57,7 +57,7 @@ def img(
             cmap = "viridis"
     elif mode == "cov":
         vmin, vmax, cmap, cbar = 0, 1, "viridis", True
-    elif mode == "cov":
+    elif mode == "corr":
         vmin, vmax, cmap, cbar = -1, 1, "seismic", True
     else:
         raise ValueError("Unrecognized mode: '" + mode + "'")


### PR DESCRIPTION
## Summary
- fix yclamp/xclamp to use full range
- rename duplicate `cov` case in `images.img` to `corr`

## Testing
- `pytest -q` *(fails: `pytest` not found)*