### PR TITLE
Fix name in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The documentation sources live in the [`docs/`](docs/) folder.
 | 0.6.0   | Jul 21 2024  | Migrated from setup.py to pyproject.toml.                                                                                                                                                     |
 | 0.5.3   | Aug 30 2022  | Stops jetplot from updating Matplotlib rcParams on import.                                                                                                                                                     |
 | 0.5.0   | Jul 15 2022  | Updates default color palettes, adds new Palette class, adds ridgeline plot.                                                                                                                                                     |
-| 0.4.0   | Oct 20 2021  | Name change! Renamed package from `jetpack` to `jetplot`.                                                                                                                                                       |
+| 0.4.0   | Oct 20 2021  | Name change! Package renamed to `jetplot`.                                                                                                                                                       |
 | 0.3.0   | Oct 13 2021  | Drops animation module and the `moviepy` dependency                                                                                                                                                             |
 | 0.0.0   | Jan 19 2015  | Initial commit                                                                                                                                                                                                  |
 

--- a/src/jetplot/__init__.py
+++ b/src/jetplot/__init__.py
@@ -1,4 +1,4 @@
-"""Jetpack is a set of useful utility functions for scientific python."""
+"""Jetplot is a set of useful utility functions for scientific python."""
 
 __version__ = "0.6.3"
 


### PR DESCRIPTION
## Summary
- fix docstring mention of Jetpack
- update README to avoid old name in changelog

## Testing
- `ruff check .`
- `pytest -q` *(fails: command not found)*